### PR TITLE
Send an empty json body if no parameters are given to an API call

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ownprojects-info/check-point-management-api",
+    "name": "martinmulder/check-point-management-api",
     "description": "PHP library for the Check Point Management API",
     "type": "library",
     "require": {
@@ -9,8 +9,8 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "Arthur",
-            "email": "admin@ownprojects.info",
+            "name": "Martin Mulder",
+            "email": "martin@serioussecurity.nl",
             "role": "Developer"
         }
     ],

--- a/src/Abstracts/Api.php
+++ b/src/Abstracts/Api.php
@@ -20,7 +20,7 @@ abstract class Api
     {
         $options = [];
 
-        if (is_array($parameters)) {
+        if (is_array($parameters) && !empty($parameters)) {
             $options['json'] = $parameters;
         }
 
@@ -30,6 +30,12 @@ abstract class Api
                 'X-chkp-sid' => $sessionToken,
             ];
         }
+
+	// Send an ampty json body if no parameters are given
+	if (empty($parameters)) {
+	    $options['headers']['Content-Type'] = "application/json";
+	    $options['body'] = "{}";
+	}
 
         $response = $this->client->getHttpClient()->post($uri, $options);
 

--- a/src/Api/AccessLayer.php
+++ b/src/Api/AccessLayer.php
@@ -1,0 +1,63 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Exceptions\CheckPointManagementApiException;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class AccessLayer
+ *
+ */
+class AccessLayer extends Api
+{
+    /**
+     * Get the datails of an AccessLayer
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-access-rule~v1.6%20
+     *
+     */
+    public function showAccessLayer(array $givenParameters)
+    {
+        $allowedParameters = [
+            'uid',
+	    'name',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-access-layer', $givenParameters);
+    }
+
+    /**
+     * Get the access layers
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-access-layers~v1.6%20
+     *
+     */
+    public function showAccessLayers(array $givenParameters)
+    {
+        $allowedParameters = [
+            'limit',
+	    'offset',
+	    'order',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-access-layers', $givenParameters);
+    }
+}

--- a/src/Api/AccessRule.php
+++ b/src/Api/AccessRule.php
@@ -1,0 +1,79 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Exceptions\CheckPointManagementApiException;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class AccessRule
+ *
+ */
+class AccessRule extends Api
+{
+    /**
+     * Get the datails of an AccessRule
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-access-rule~v1.6%20
+     *
+     */
+    public function showAccessRule(array $givenParameters)
+    {
+        $allowedParameters = [
+            'uid',
+	    'name',
+	    'rule-number',
+	    'layer',
+	    'show-as-ranges',
+	    'show-hits',
+	    'hits-settings',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-access-rule', $givenParameters);
+    }
+
+    /**
+     * Get the access rulebase
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-access-rulebase~v1.6%20
+     *
+     */
+    public function showAccessRulebase(array $givenParameters)
+    {
+        $allowedParameters = [
+	    'name',
+	    'uid',
+	    'filter',
+	    'filter-settings',
+            'limit',
+	    'offset',
+	    'order',
+	    'package',
+	    'show-as-ranges',
+	    'show-hits',
+	    'use-object-dictionary',
+	    'hits-settings',
+	    'dereference-group-members',
+	    'show-membership',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-access-rulebase', $givenParameters);
+    }
+}

--- a/src/Api/Manage.php
+++ b/src/Api/Manage.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Exceptions\CheckPointManagementApiException;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class Manage
+ *
+ * @method \CheckPoint\ManagementApi\Api\Manage\Administrator administrator()
+ */
+class Manage extends Api
+{
+    public function __call($method, $arguments)
+    {
+        $pascalCaseMethod = ucfirst($method);
+        $classPath        = __CLASS__ . "\\{$pascalCaseMethod}";
+
+        if (class_exists($classPath)) {
+            return new $classPath($this->client);
+        }
+
+        throw new CheckPointManagementApiException("Method {$method} does not exist");
+    }
+}

--- a/src/Api/Manage/Administrator.php
+++ b/src/Api/Manage/Administrator.php
@@ -1,0 +1,62 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api\Misc;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class Administrator
+ */
+class Administrator extends Api
+{
+    /**
+     * Get the datails of an administrator
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-administrator~v1.6%20
+     *
+     */
+    public function showAdministrator(array $givenParameters)
+    {
+        $allowedParameters = [
+            'uid',
+            'name',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-administrator', $givenParameters);
+    }
+
+    /**
+     * Get a list of administrators
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-administrators~v1.6%20
+     *
+     */
+    public function showAdministrators(array $givenParameters)
+    {
+        $allowedParameters = [
+            'limit',
+            'offset',
+            'order',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-administrators', $givenParameters);
+    }
+
+}

--- a/src/Api/Misc.php
+++ b/src/Api/Misc.php
@@ -15,6 +15,34 @@ use CheckPoint\ManagementApi\Tools\Validator;
  */
 class Misc extends Api
 {
+    /**
+     * Get a list of changes between dates or sessions
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-changes~v1.6%20
+     *
+     */
+    public function showChanges(array $givenParameters)
+    {
+        $allowedParameters = [
+            'from-date',
+            'from-session',
+            'limit',
+            'offset',
+            'to-date',
+            'to-session',
+            'dereference-group-members',
+            'show-membership',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-changes', $givenParameters);
+    }
 
     public function __call($method, $arguments)
     {

--- a/src/Api/Misc.php
+++ b/src/Api/Misc.php
@@ -95,6 +95,32 @@ class Misc extends Api
         return $this->request('show-object', $givenParameters);
     }
 
+    /**
+     * Get ta list of an objects
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-unused-objects~v1.6%20
+     *
+     */
+    public function showUnusedPbjects(array $givenParameters)
+    {
+        $allowedParameters = [
+            'limit',
+            'offset',
+            'order',
+            'dereference-group-members',
+            'show-membership',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-unused-objects', $givenParameters);
+    }
+
     public function __call($method, $arguments)
     {
         $pascalCaseMethod = ucfirst($method);

--- a/src/Api/Misc.php
+++ b/src/Api/Misc.php
@@ -73,6 +73,28 @@ class Misc extends Api
         return $this->request('show-objects', $givenParameters);
     }
 
+    /**
+     * Get the details of an object
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-object~v1.6%20
+     *
+     */
+    public function showObject(array $givenParameters)
+    {
+        $allowedParameters = [
+            'uid',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-object', $givenParameters);
+    }
+
     public function __call($method, $arguments)
     {
         $pascalCaseMethod = ucfirst($method);

--- a/src/Api/Misc.php
+++ b/src/Api/Misc.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Exceptions\CheckPointManagementApiException;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class Misc
+ *
+ * @method \CheckPoint\ManagementApi\Api\Misc\Task task()
+ */
+class Misc extends Api
+{
+
+    public function __call($method, $arguments)
+    {
+        $pascalCaseMethod = ucfirst($method);
+        $classPath        = __CLASS__ . "\\{$pascalCaseMethod}";
+
+        if (class_exists($classPath)) {
+            return new $classPath($this->client);
+        }
+
+        throw new CheckPointManagementApiException("Method {$method} does not exist");
+    }
+}

--- a/src/Api/Misc.php
+++ b/src/Api/Misc.php
@@ -44,6 +44,35 @@ class Misc extends Api
         return $this->request('show-changes', $givenParameters);
     }
 
+    /**
+     * Get a list of objects
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-objects~v1.6%20
+     *
+     */
+    public function showObjects(array $givenParameters)
+    {
+        $allowedParameters = [
+            'filter',
+            'ip-only',
+            'limit',
+            'offset',
+	    'order',
+            'type',
+            'dereference-group-members',
+            'show-membership',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-objects', $givenParameters);
+    }
+
     public function __call($method, $arguments)
     {
         $pascalCaseMethod = ucfirst($method);

--- a/src/Api/Misc.php
+++ b/src/Api/Misc.php
@@ -105,7 +105,7 @@ class Misc extends Api
      * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-unused-objects~v1.6%20
      *
      */
-    public function showUnusedPbjects(array $givenParameters)
+    public function showUnusedObjects(array $givenParameters)
     {
         $allowedParameters = [
             'limit',

--- a/src/Api/Misc/Task.php
+++ b/src/Api/Misc/Task.php
@@ -1,0 +1,65 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api\Misc;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class Task
+ */
+class Task extends Api
+{
+    /**
+     * Get the datails of a task
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-task~v1.6%20
+     *
+     */
+    public function showTask(array $givenParameters)
+    {
+        $allowedParameters = [
+            'task-id',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-task', $givenParameters);
+    }
+
+    /**
+     * Get a list of tasks
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-tasks~v1.6%20
+     *
+     */
+    public function showTasks(array $givenParameters)
+    {
+    
+    	$allowedParameters = [
+    		'initiator',
+    		'status',
+    		'from-date',
+    		'to-date',
+    		'limit',
+    		'offset',
+    		'order',
+    		'details-level',
+    	];
+
+    	Validator::checkParameters($givenParameters, $allowedParameters);
+
+    	return $this->request('show-tasks', $givenParameters);
+    }
+}

--- a/src/Api/MultiDomain.php
+++ b/src/Api/MultiDomain.php
@@ -1,0 +1,77 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Exceptions\CheckPointManagementApiException;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class MultiDomain
+ *
+ * @method \CheckPoint\ManagementApi\Api\MultiDomain\Domain domain()
+ * @method \CheckPoint\ManagementApi\Api\MultiDomain\GlobalDomain globalDomain()
+ */
+class MultiDomain extends Api
+{
+    /**
+     * Get the datails of a Multi-Domain-Server
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-mds~v1.6%20
+     *
+     */
+    public function showMds(array $givenParameters)
+    {
+        $allowedParameters = [
+            'uid',
+	    'name',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-mds', $givenParameters);
+    }
+
+    /**
+     * Get a list of  Multi-Domain-Servers
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-mdss~v1.6%20
+     *
+     */
+    public function showMdss(array $givenParameters)
+    {
+        $allowedParameters = [
+            'limit',
+	    'offset',
+	    'order',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-mdss', $givenParameters);
+    }
+
+    public function __call($method, $arguments)
+    {
+        $pascalCaseMethod = ucfirst($method);
+        $classPath        = __CLASS__ . "\\{$pascalCaseMethod}";
+
+        if (class_exists($classPath)) {
+            return new $classPath($this->client);
+        }
+
+        throw new CheckPointManagementApiException("Method {$method} does not exist");
+    }
+}

--- a/src/Api/MultiDomain/Domain.php
+++ b/src/Api/MultiDomain/Domain.php
@@ -1,0 +1,62 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api\MultiDomain;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class Domain
+ */
+class Domain extends Api
+{
+    /**
+     * Get the datails of a domain
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-domain~v1.6%20
+     *
+     */
+    public function showDomain(array $givenParameters)
+    {
+        $allowedParameters = [
+           'uid',
+	       'name',
+           'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-domain', $givenParameters);
+    }
+
+    /**
+     * Get a list of domains
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-domains~v1.6%20
+     *
+     */
+    public function showDomains(array $givenParameters)
+    {
+    
+    	$allowedParameters = [
+    		'limit',
+    		'offset',
+    		'order',
+    		'details-level',
+    	];
+
+    	Validator::checkParameters($givenParameters, $allowedParameters);
+
+    	return $this->request('show-domains', $givenParameters);
+    }
+}

--- a/src/Api/MultiDomain/GlobalDomain.php
+++ b/src/Api/MultiDomain/GlobalDomain.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api\MultiDomain;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class GlobalDomain
+ */
+class GlobalDomain extends Api
+{
+    /**
+     * Get the datails of the global domain
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-global-domain~v1.6%20
+     *
+     */
+    public function showGlobalDomain(array $givenParameters)
+    {
+        $allowedParameters = [
+           'uid',
+	       'name',
+           'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-global-domain', $givenParameters);
+    }
+}

--- a/src/Api/NatRule.php
+++ b/src/Api/NatRule.php
@@ -1,0 +1,70 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Exceptions\CheckPointManagementApiException;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class NatRule
+ *
+ */
+class NatRule extends Api
+{
+    /**
+     * Get the datails of an NatRule
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-nat-rule~v1.6%20
+     *
+     */
+    public function showNatRule(array $givenParameters)
+    {
+        $allowedParameters = [
+            'uid',
+	    'rule-number',
+	    'package',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-nat-rule', $givenParameters);
+    }
+
+    /**
+     * Get the NAT rulebase
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-nat-rulebase~v1.6%20
+     *
+     */
+    public function showNatRulebase(array $givenParameters)
+    {
+        $allowedParameters = [
+	    'package',
+	    'filter',
+	    'filter-settings',
+            'limit',
+	    'offset',
+	    'order',
+	    'use-object-dictionary',
+	    'dereference-group-members',
+	    'show-membership',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-nat-rulebase', $givenParameters);
+    }
+}

--- a/src/Api/NetworkObjects.php
+++ b/src/Api/NetworkObjects.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Exceptions\CheckPointManagementApiException;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class NetworkObjects
+ *
+ * @method \CheckPoint\ManagementApi\Api\NetworkObjects\LsvProfile lsvProfile()
+ */
+class NetworkObjects extends Api
+{
+    public function __call($method, $arguments)
+    {
+        $pascalCaseMethod = ucfirst($method);
+        $classPath        = __CLASS__ . "\\{$pascalCaseMethod}";
+
+        if (class_exists($classPath)) {
+            return new $classPath($this->client);
+        }
+
+        throw new CheckPointManagementApiException("Method {$method} does not exist");
+    }
+}

--- a/src/Api/NetworkObjects/LsvProfile.php
+++ b/src/Api/NetworkObjects/LsvProfile.php
@@ -1,0 +1,61 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api\NetworkObjects;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class LsvProfile
+ */
+class LsvProfile extends Api
+{
+    /**
+     * Get the datails of a lsvProfile
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-lsv-profile~v1.6%20
+     *
+     */
+    public function showLsvProfile(array $givenParameters)
+    {
+        $allowedParameters = [
+            'uid',
+            'name',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-lsv-profile', $givenParameters);
+    }
+
+    /**
+     * Get a list of a lsv profiles
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-lsv-profiles~v1.6%20
+     *
+     */
+    public function showLsvProfiles(array $givenParameters)
+    {
+        $allowedParameters = [
+            'limit',
+            'offset',
+            'order',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-lsv-profiles', $givenParameters);
+    }
+}

--- a/src/Api/PackageDeployment.php
+++ b/src/Api/PackageDeployment.php
@@ -1,0 +1,48 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Exceptions\CheckPointManagementApiException;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class PackageDeployment
+ */
+class PackageDeployment extends Api
+{
+    /**
+     * Get the software package details
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-software-package-details~v1.6%20
+     *
+     */
+	public function showSoftwarePackageDetails(array $givenParameters)
+	{
+			$allowedParameters = [
+					'name',
+			];
+
+			Validator::checkParameters($givenParameters, $allowedParameters);
+
+			return $this->request('show-software-package-details', $givenParameters);
+	}
+
+    public function __call($method, $arguments)
+    {
+        $pascalCaseMethod = ucfirst($method);
+        $classPath        = __CLASS__ . "\\{$pascalCaseMethod}";
+
+        if (class_exists($classPath)) {
+            return new $classPath($this->client);
+        }
+
+        throw new CheckPointManagementApiException("Method {$method} does not exist");
+    }
+}

--- a/src/Api/Policy.php
+++ b/src/Api/Policy.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Exceptions\CheckPointManagementApiException;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class Policy
+ *
+ * @method \CheckPoint\ManagementApi\Api\Policy\PolicyPackage policyPackage()
+ */
+class Policy extends Api
+{
+    public function __call($method, $arguments)
+    {
+        $pascalCaseMethod = ucfirst($method);
+        $classPath        = __CLASS__ . "\\{$pascalCaseMethod}";
+
+        if (class_exists($classPath)) {
+            return new $classPath($this->client);
+        }
+
+        throw new CheckPointManagementApiException("Method {$method} does not exist");
+    }
+}

--- a/src/Api/Policy/PolicyPackage.php
+++ b/src/Api/Policy/PolicyPackage.php
@@ -34,4 +34,28 @@ class PolicyPackage extends Api
 
         return $this->request('show-package', $givenParameters);
     }
+
+    /**
+     * Get a list of a packages
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-packages~v1.6%20
+     *
+     */
+    public function showPackages(array $givenParameters)
+    {
+        $allowedParameters = [
+            'limit',
+            'offset',
+            'order',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-packages', $givenParameters);
+    }
 }

--- a/src/Api/Policy/PolicyPackage.php
+++ b/src/Api/Policy/PolicyPackage.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api\Policy;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class PolicyPackage
+ */
+class PolicyPackage extends Api
+{
+    /**
+     * Get the datails of a package
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-package~v1.6%20
+     *
+     */
+    public function showPackage(array $givenParameters)
+    {
+        $allowedParameters = [
+            'uid',
+            'name',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-package', $givenParameters);
+    }
+}

--- a/src/Api/SessionManagement.php
+++ b/src/Api/SessionManagement.php
@@ -12,7 +12,6 @@ use CheckPoint\ManagementApi\Tools\Validator;
  * Class SessionManagement
  *
  * @method \CheckPoint\ManagementApi\Api\SessionManagement\Session session()
- * @method \CheckPoint\ManagementApi\Api\SessionManagement\LoginMessage loginMessage()
  */
 class SessionManagement extends Api
 {

--- a/src/Api/SessionManagement/Session.php
+++ b/src/Api/SessionManagement/Session.php
@@ -7,8 +7,21 @@ namespace CheckPoint\ManagementApi\Api\SessionManagement;
 use CheckPoint\ManagementApi\Abstracts\Api;
 use CheckPoint\ManagementApi\Tools\Validator;
 
+/**
+ * Class Session
+ */
 class Session extends Api
 {
+	/**
+     * Show session details
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-session~v1.6%20
+     *
+     */
     public function showSession(array $givenParameters)
     {
         $allowedParameters = [

--- a/src/Api/SmartTasks.php
+++ b/src/Api/SmartTasks.php
@@ -1,0 +1,77 @@
+<?php
+
+
+namespace CheckPoint\ManagementApi\Api;
+
+
+use CheckPoint\ManagementApi\Abstracts\Api;
+use CheckPoint\ManagementApi\Exceptions\CheckPointManagementApiException;
+use CheckPoint\ManagementApi\Tools\Validator;
+
+/**
+ * Class SmartTasks
+ *
+ * @method \CheckPoint\ManagementApi\Api\SmartTasks\Triggers triggers()
+ */
+class SmartTasks extends Api
+{
+
+	/**
+     * Get a list of SmartTasks
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-smart-tasks~v1.6%20
+     *
+     */
+    public function showSmartTasks(array $givenParameters)
+    {
+        $allowedParameters = [
+            'limit',
+            'offset',
+		    'order',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-smart-tasks', $givenParameters);
+    }
+
+	/**
+     * Get the details of a SmartTask
+     *
+     * @param array $givenParameters
+     *
+     * @return mixed|\Psr\Http\Message\StreamInterface
+     * @throws CheckPointManagementApiException
+     * @link https://sc1.checkpoint.com/documents/latest/APIs/index.html#web/show-smart-task-v1.6%20
+     *
+     */
+    public function showSmartTask(array $givenParameters)
+    {
+        $allowedParameters = [
+            'name',
+            'uid',
+            'details-level',
+        ];
+
+        Validator::checkParameters($givenParameters, $allowedParameters);
+
+        return $this->request('show-smart-task', $givenParameters);
+    }
+
+    public function __call($method, $arguments)
+    {
+        $pascalCaseMethod = ucfirst($method);
+        $classPath        = __CLASS__ . "\\{$pascalCaseMethod}";
+
+        if (class_exists($classPath)) {
+            return new $classPath($this->client);
+        }
+
+        throw new CheckPointManagementApiException("Method {$method} does not exist");
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client
 
     const API_VERSION = 'v1.6';
 
-    const BASE_URI = 'https:///%s:%s/web_api/%s/';
+    const BASE_URI = 'https://%s:%s/web_api/%s/';
 
     const BASE_URI_NO_PORT = 'https://%s/web_api/%s/';
 


### PR DESCRIPTION
If there are no parameters given to a API call, the body will be empty.
The checkpoint API will return an error:

{
  "code" : "generic_err_invalid_syntax",
  "message" : "Payload is empty"
}

This patch sends an empty json body if no parameters are given.

Also fixes a simple typo (tripple slash in base URL)